### PR TITLE
Now clears all selected text when exiting

### DIFF
--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
@@ -28,6 +28,9 @@ namespace GitWrite.Views
             VerticalAlignment = VerticalAlignment.Top
          };
 
+         CommitText.SelectionLength = 0;
+         SecondaryCommitText.SelectionLength = 0;
+
          MainGrid.Children.Add( exitPanel );
 
          return exitPanel.ShowAsync();


### PR DESCRIPTION
Otherwise it would show up, still highlighted, under the exit panel.