### PR TITLE
Changing to Preview Mouse Down for the window drag behavior

### DIFF
--- a/src/GitWrite/GitWrite/Views/WindowDragBehavior.cs
+++ b/src/GitWrite/GitWrite/Views/WindowDragBehavior.cs
@@ -8,12 +8,12 @@ namespace GitWrite.Views
    {
       protected override void OnAttached()
       {
-         AssociatedObject.MouseDown += OnMouseDown;
+         AssociatedObject.PreviewMouseDown += OnMouseDown;
       }
 
       protected override void OnDetaching()
       {
-         AssociatedObject.MouseDown -= OnMouseDown;
+         AssociatedObject.PreviewMouseDown -= OnMouseDown;
       }
 
       private void OnMouseDown( object sender, MouseButtonEventArgs e )


### PR DESCRIPTION
This allows the handler to go off more aggressively, triggering when
the mouse is pressed over any control. This allows dragging from anywhere.