### PR TITLE
Expand button is no longer a tab stop

### DIFF
--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml
@@ -165,6 +165,7 @@
                <Button Grid.Row="2"
                   Foreground="{StaticResource WindowCommitForegroundColor}"
                   Content="?"
+                  IsTabStop="False"
                   Command="{Binding HelpCommand, Mode=OneTime}"/>
             </Grid>
          </Grid>


### PR DESCRIPTION
This means you can only tab between the two text fields.