### PR TITLE
Now trims the end of the incoming short message

### DIFF
--- a/src/GitWrite/GitWrite/CommitFileReader.cs
+++ b/src/GitWrite/GitWrite/CommitFileReader.cs
@@ -56,7 +56,7 @@ namespace GitWrite
             if ( !hasFoundShortMessage )
             {
                hasFoundShortMessage = true;
-               commitDocument.ShortMessage = line;
+               commitDocument.ShortMessage = line.TrimEnd();
             }
             else
             {


### PR DESCRIPTION
Seems like preserving leading spaces would be relevant? I dunno, maybe--
for formatting or something? I don't know how trailing spaces would be
meaningful, so those get chopped.