### PR TITLE
Enter no longer auto-submits when editing secondary notes

### DIFF
--- a/src/GitWrite/GitWrite/Behaviors/CommitKeyPressBehavior.cs
+++ b/src/GitWrite/GitWrite/Behaviors/CommitKeyPressBehavior.cs
@@ -11,10 +11,10 @@ namespace GitWrite.Behaviors
    {
       private readonly CommitViewModel _commitViewModel = SimpleIoc.Default.GetInstance<CommitViewModel>();
 
-      protected override void OnAttached() => AssociatedObject.PreviewKeyDown += PreviewKeyDown;
-      protected override void OnDetaching() => AssociatedObject.PreviewKeyDown -= PreviewKeyDown;
+      protected override void OnAttached() => AssociatedObject.KeyDown += KeyDown;
+      protected override void OnDetaching() => AssociatedObject.KeyDown -= KeyDown;
       
-      public void PreviewKeyDown( object sender, KeyEventArgs e )
+      public void KeyDown( object sender, KeyEventArgs e )
       {
          switch ( _commitViewModel.InputState )
          {


### PR DESCRIPTION
The keypress behavior was using PreviewKeyDown, so it caught it at the
top level (tunneling, instead of bubbling). Switching it to KeyDown
(bubbling), the secondary notes field gets a chance to suppress the
Enter keypress and apply its own behavior.