### PR TITLE
Secondary notes no longer clobber together with primary during rebase

### DIFF
--- a/src/GitWrite/GitWrite.UnitTests/CommitDocumentTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/CommitDocumentTests.cs
@@ -62,7 +62,7 @@ namespace GitWrite.UnitTests
          fileAdapterMock.Setup( fa => fa.WriteAllLines( It.IsAny<string>(), It.IsAny<IEnumerable<string>>() ) ).Callback<string, IEnumerable<string>>( ( p, l ) =>
          {
             var lines = l.ToList();
-            parametersMatch = (p == path && lines[0] == shortMessage && lines[1] == longMessage);
+            parametersMatch = (p == path && lines[0] == shortMessage && lines[1] == string.Empty && lines[2] == longMessage);
          } );
          SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
@@ -96,7 +96,7 @@ namespace GitWrite.UnitTests
          fileAdapterMock.Setup( fa => fa.WriteAllLines( It.IsAny<string>(), It.IsAny<IEnumerable<string>>() ) ).Callback<string, IEnumerable<string>>( ( p, l ) =>
          {
             var lines = l.ToList();
-            parametersMatch = ( p == path && lines[0] == shortMessage && lines[1] == longMessage );
+            parametersMatch = ( p == path && lines[0] == shortMessage && lines[1] == string.Empty && lines[2] == longMessage );
          } );
          SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 

--- a/src/GitWrite/GitWrite/CommitDocument.cs
+++ b/src/GitWrite/GitWrite/CommitDocument.cs
@@ -33,6 +33,7 @@ namespace GitWrite
          var lines = new[]
          {
             ShortMessage,
+            string.Empty,
             LongMessage
          };
 


### PR DESCRIPTION
My best guess is because there was no blank line separating the two
sets of notes. When saving, there's now a blank line written between
them. Also updated tests to account for it.