### PR TITLE
Changing how dependencies are delivered

### DIFF
--- a/src/GitWrite/GitWrite.UnitTests/AppControllerTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/AppControllerTests.cs
@@ -75,8 +75,6 @@ namespace GitWrite.UnitTests
          var commitFileReaderMock = new Mock<ICommitFileReader>();
          commitFileReaderMock.Setup( cfr => cfr.FromFile( It.IsAny<string>() ) ).Returns( commitDocument );    
 
-         App.CommitDocument = null;
-
          // Test
 
          var arguments = new[]
@@ -102,8 +100,6 @@ namespace GitWrite.UnitTests
 
          var commitFileReaderMock = new Mock<ICommitFileReader>();
          commitFileReaderMock.Setup( cfr => cfr.FromFile( It.IsAny<string>() ) ).Throws<GitFileLoadException>();
-
-         App.CommitDocument = null;
 
          // Test
 

--- a/src/GitWrite/GitWrite.UnitTests/AppControllerTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/AppControllerTests.cs
@@ -68,7 +68,7 @@ namespace GitWrite.UnitTests
       [Fact]
       public void Start_HasCommandLineArgument_CommitDocumentIsStoredOnApp()
       {
-         var commitDocument = new CommitDocument();
+         var commitDocument = new CommitDocument( null );
 
          // Setup
 

--- a/src/GitWrite/GitWrite.UnitTests/AppControllerTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/AppControllerTests.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using GalaSoft.MvvmLight.Ioc;
 using Moq;
 using Xunit;
 
@@ -7,22 +6,16 @@ namespace GitWrite.UnitTests
 {
    public class AppControllerTest
    {
-      public AppControllerTest()
-      {
-         SimpleIoc.Default.Reset();
-      }
-
       [Fact]
       public void Start_CommandLineArgumentsAreNull_ExitsWithCodeOne()
       {
          // Setup
 
          var environmentAdapterMock = new Mock<IEnvironmentAdapter>();
-         SimpleIoc.Default.Register( () => environmentAdapterMock.Object );
 
          // Test
 
-         var appController = new AppController();
+         var appController = new AppController( environmentAdapterMock.Object, null );
 
          appController.Start( null );
 
@@ -37,11 +30,10 @@ namespace GitWrite.UnitTests
          // Setup
 
          var environmentAdapterMock = new Mock<IEnvironmentAdapter>();
-         SimpleIoc.Default.Register( () => environmentAdapterMock.Object );
 
          // Test
 
-         var appController = new AppController();
+         var appController = new AppController( environmentAdapterMock.Object, null );
 
          appController.Start( new string[0] );
 
@@ -56,7 +48,6 @@ namespace GitWrite.UnitTests
          // Setup
 
          var commitFileReaderMock = new Mock<ICommitFileReader>();
-         SimpleIoc.Default.Register( () => commitFileReaderMock.Object );
 
          // Test
 
@@ -65,7 +56,7 @@ namespace GitWrite.UnitTests
             GitFileNames.CommitFileName
          };
 
-         var appController = new AppController();
+         var appController = new AppController( null, commitFileReaderMock.Object );
 
          appController.Start( arguments );
 
@@ -83,7 +74,6 @@ namespace GitWrite.UnitTests
 
          var commitFileReaderMock = new Mock<ICommitFileReader>();
          commitFileReaderMock.Setup( cfr => cfr.FromFile( It.IsAny<string>() ) ).Returns( commitDocument );    
-         SimpleIoc.Default.Register( () => commitFileReaderMock.Object );
 
          App.CommitDocument = null;
 
@@ -94,7 +84,7 @@ namespace GitWrite.UnitTests
             GitFileNames.CommitFileName
          };
 
-         var appController = new AppController();
+         var appController = new AppController( null, commitFileReaderMock.Object );
 
          appController.Start( arguments );
 
@@ -109,11 +99,9 @@ namespace GitWrite.UnitTests
          // Setup
 
          var environmentAdapterMock = new Mock<IEnvironmentAdapter>();
-         SimpleIoc.Default.Register( () => environmentAdapterMock.Object );
 
          var commitFileReaderMock = new Mock<ICommitFileReader>();
          commitFileReaderMock.Setup( cfr => cfr.FromFile( It.IsAny<string>() ) ).Throws<GitFileLoadException>();
-         SimpleIoc.Default.Register( () => commitFileReaderMock.Object );
 
          App.CommitDocument = null;
 
@@ -124,7 +112,7 @@ namespace GitWrite.UnitTests
             "Some Argument"
          };
 
-         var appController = new AppController();
+         var appController = new AppController( environmentAdapterMock.Object, commitFileReaderMock.Object );
 
          appController.Start( arguments );
 
@@ -139,7 +127,6 @@ namespace GitWrite.UnitTests
          // Setup
 
          var environmentAdapterMock = new Mock<IEnvironmentAdapter>();
-         SimpleIoc.Default.Register( () => environmentAdapterMock.Object );
 
          // Test
 
@@ -148,7 +135,7 @@ namespace GitWrite.UnitTests
             "Not a Git file"
          };
 
-         var appController = new AppController();
+         var appController = new AppController( environmentAdapterMock.Object, null );
 
          appController.Start( arguments );
 

--- a/src/GitWrite/GitWrite.UnitTests/AppControllerTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/AppControllerTests.cs
@@ -86,11 +86,11 @@ namespace GitWrite.UnitTests
 
          var appController = new AppController( null, commitFileReaderMock.Object );
 
-         appController.Start( arguments );
+         var actualCommitDocument = appController.Start( arguments );
 
          // Assert
 
-         App.CommitDocument.Should().Be( commitDocument );
+         actualCommitDocument.Should().Be( commitDocument );
       }
 
       [Fact]

--- a/src/GitWrite/GitWrite.UnitTests/CommitDocumentTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/CommitDocumentTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using GalaSoft.MvvmLight.Ioc;
 using Moq;
 using Xunit;
 
@@ -10,11 +9,6 @@ namespace GitWrite.UnitTests
 {
    public class CommitDocumentTests
    {
-      public CommitDocumentTests()
-      {
-         SimpleIoc.Default.Reset();
-      }
-
       [Fact]
       public void Save_OnlyHasShortMessage_WritesCommitNotes()
       {
@@ -30,11 +24,10 @@ namespace GitWrite.UnitTests
             var lines = l.ToList();
             parametersMatch = ( p == path && lines[0] == shortMessage );
          } );    
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitDocument = new CommitDocument
+         var commitDocument = new CommitDocument( fileAdapterMock.Object )
          {
             Name = path,
             ShortMessage = shortMessage
@@ -63,11 +56,10 @@ namespace GitWrite.UnitTests
             var lines = l.ToList();
             parametersMatch = (p == path && lines[0] == shortMessage && lines[1] == string.Empty && lines[2] == longMessage);
          } );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitDocument = new CommitDocument
+         var commitDocument = new CommitDocument( fileAdapterMock.Object )
          {
             Name = path,
             ShortMessage = shortMessage,
@@ -97,11 +89,10 @@ namespace GitWrite.UnitTests
             var lines = l.ToList();
             parametersMatch = ( p == path && lines[0] == shortMessage && lines[1] == string.Empty && lines[2] == longMessage );
          } );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitDocument = new CommitDocument
+         var commitDocument = new CommitDocument( fileAdapterMock.Object )
          {
             Name = path,
             ShortMessage = shortMessage,

--- a/src/GitWrite/GitWrite.UnitTests/CommitFileReaderTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/CommitFileReaderTests.cs
@@ -19,11 +19,10 @@ namespace GitWrite.UnitTests
          // Setup
 
          var fileAdapterMock = new Mock<IFileAdapter>();
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          Assert.Throws<GitFileLoadException>( () => commitFileReader.FromFile( "SomeFile" ) );
       }
@@ -42,11 +41,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          commitFileReader.FromFile( path );
 
@@ -71,11 +69,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( lines );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -100,11 +97,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -124,11 +120,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          Assert.Throws<GitFileLoadException>( () => commitFileReader.FromFile( path ) );
       }
@@ -144,11 +139,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          Assert.Throws<GitFileLoadException>( () => commitFileReader.FromFile( path ) );
       }
@@ -173,11 +167,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -209,11 +202,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -245,11 +237,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -283,11 +274,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -321,11 +311,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -361,11 +350,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -403,11 +391,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -448,11 +435,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -492,11 +478,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -531,11 +516,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -563,11 +547,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -599,11 +582,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 
@@ -636,11 +618,10 @@ namespace GitWrite.UnitTests
          var fileAdapterMock = new Mock<IFileAdapter>();
          fileAdapterMock.Setup( fa => fa.Exists( path ) ).Returns( true );
          fileAdapterMock.Setup( fa => fa.ReadAllLines( path ) ).Returns( contents );
-         SimpleIoc.Default.Register( () => fileAdapterMock.Object );
 
          // Test
 
-         var commitFileReader = new CommitFileReader();
+         var commitFileReader = new CommitFileReader( fileAdapterMock.Object );
 
          var commitDocument = commitFileReader.FromFile( path );
 

--- a/src/GitWrite/GitWrite.UnitTests/Services/ApplicationSettingsTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/Services/ApplicationSettingsTests.cs
@@ -1,19 +1,13 @@
-﻿using FluentAssertions;
-using GalaSoft.MvvmLight.Ioc;
-using GitWrite.Services;
-using Microsoft.Win32;
+﻿using Microsoft.Win32;
+using FluentAssertions;
 using Moq;
 using Xunit;
+using GitWrite.Services;
 
 namespace GitWrite.UnitTests.Services
 {
    public class ApplicationSettingsTests
    {
-      public ApplicationSettingsTests()
-      {
-         SimpleIoc.Default.Reset();
-      }
-
       [Fact]
       public void ThemeProperty_SetsThemeName_IsStoredWithRegistry()
       {
@@ -22,11 +16,10 @@ namespace GitWrite.UnitTests.Services
          // Setup
 
          var registryServiceMock = new Mock<IRegistryService>();
-         SimpleIoc.Default.Register( () => registryServiceMock.Object );
 
          // Test
 
-         var appSettings = new ApplicationSettings
+         var appSettings = new ApplicationSettings( registryServiceMock.Object )
          {
             Theme = themeName
          };
@@ -45,11 +38,10 @@ namespace GitWrite.UnitTests.Services
 
          var registryServiceMock = new Mock<IRegistryService>();
          registryServiceMock.Setup( rs => rs.ReadString( It.IsAny<RegistryKey>(), It.IsAny<string>(), It.IsAny<string>() ) ).Returns( themeName );
-         SimpleIoc.Default.Register( () => registryServiceMock.Object );
 
          // Test
 
-         var appSettings = new ApplicationSettings();
+         var appSettings = new ApplicationSettings( registryServiceMock.Object );
          string actualThemeName = appSettings.Theme;
 
          // Assert
@@ -65,11 +57,10 @@ namespace GitWrite.UnitTests.Services
          // Setup
 
          var registryServiceMock = new Mock<IRegistryService>();
-         SimpleIoc.Default.Register( () => registryServiceMock.Object );
 
          // Test
 
-         var appSettings = new ApplicationSettings
+         var appSettings = new ApplicationSettings( registryServiceMock.Object )
          {
             WindowX = x
          };
@@ -88,11 +79,10 @@ namespace GitWrite.UnitTests.Services
 
          var registryServiceMock = new Mock<IRegistryService>();
          registryServiceMock.Setup( rs => rs.ReadInt( It.IsAny<RegistryKey>(), It.IsAny<string>(), It.IsAny<string>() ) ).Returns( x );
-         SimpleIoc.Default.Register( () => registryServiceMock.Object );
 
          // Test
 
-         var appSettings = new ApplicationSettings();
+         var appSettings = new ApplicationSettings( registryServiceMock.Object );
          int actualWindowX = appSettings.WindowX;
 
          // Assert
@@ -108,11 +98,10 @@ namespace GitWrite.UnitTests.Services
          // Setup
 
          var registryServiceMock = new Mock<IRegistryService>();
-         SimpleIoc.Default.Register( () => registryServiceMock.Object );
 
          // Test
 
-         var appSettings = new ApplicationSettings
+         var appSettings = new ApplicationSettings( registryServiceMock.Object )
          {
             WindowY = y
          };
@@ -131,11 +120,10 @@ namespace GitWrite.UnitTests.Services
 
          var registryServiceMock = new Mock<IRegistryService>();
          registryServiceMock.Setup( rs => rs.ReadInt( It.IsAny<RegistryKey>(), It.IsAny<string>(), It.IsAny<string>() ) ).Returns( y );
-         SimpleIoc.Default.Register( () => registryServiceMock.Object );
 
          // Test
 
-         var appSettings = new ApplicationSettings();
+         var appSettings = new ApplicationSettings( registryServiceMock.Object );
          int actualWindowY = appSettings.WindowY;
 
          // Assert

--- a/src/GitWrite/GitWrite.UnitTests/ViewModels/CommitViewModelTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/ViewModels/CommitViewModelTests.cs
@@ -9,38 +9,17 @@ namespace GitWrite.UnitTests.ViewModels
 {
    public class CommitViewModelTests
    {
-      public CommitViewModelTests()
-      {
-         App.CommitDocument = null;
-      }
-
       [Fact]
       public void ViewLoaded_DoesNotHaveExtraNotes_DoesNotRaiseExpansionEvent()
       {
          bool expanded = false;
 
-         var commitViewModel = new CommitViewModel( null, null, null );
+         var commitViewModel = new CommitViewModel( null, null, null, null );
          commitViewModel.ExpansionRequested += ( sender, e ) => expanded = true;
 
          commitViewModel.ViewLoaded();
 
          expanded.Should().BeFalse();
-      }
-
-      [Fact]
-      public void ViewLoaded_HasExtraNotes_RaisesExpansionEvent()
-      {
-         bool expanded = false;
-
-         var commitViewModel = new CommitViewModel( null, null, null )
-         {
-            ExtraCommitText = "Extra notes"
-         };
-
-         commitViewModel.ExpansionRequested += ( sender, e ) => expanded = true;
-         commitViewModel.ViewLoaded();
-
-         expanded.Should().BeTrue();
       }
 
       [Fact]
@@ -53,11 +32,9 @@ namespace GitWrite.UnitTests.ViewModels
          var commitDocumentMock = new Mock<ICommitDocument>();
          commitDocumentMock.SetupGet( cd => cd.ShortMessage ).Returns( shortMessage );
 
-         App.CommitDocument = commitDocumentMock.Object;
-
          // Test
 
-         var commitViewModel = new CommitViewModel( null, null, null );
+         var commitViewModel = new CommitViewModel( null, null, null, commitDocumentMock.Object );
 
          commitViewModel.ShortMessage.Should().Be( shortMessage );
       }
@@ -72,13 +49,27 @@ namespace GitWrite.UnitTests.ViewModels
          var commitDocumentMock = new Mock<ICommitDocument>();
          commitDocumentMock.SetupGet( cd => cd.LongMessage ).Returns( longMessage );
 
-         App.CommitDocument = commitDocumentMock.Object;
-
          // Test
 
-         var commitViewModel = new CommitViewModel( null, null, null );
+         var commitViewModel = new CommitViewModel( null, null, null, commitDocumentMock.Object );
 
          commitViewModel.ExtraCommitText.Should().Be( longMessage );
+      }
+
+      [Fact]
+      public void ViewLoaded_HasExtraNotes_RaisesExpansionEvent()
+      {
+         bool expanded = false;
+
+         var commitViewModel = new CommitViewModel( null, null, null, null )
+         {
+            ExtraCommitText = "Extra notes"
+         };
+
+         commitViewModel.ExpansionRequested += ( sender, e ) => expanded = true;
+         commitViewModel.ViewLoaded();
+
+         expanded.Should().BeTrue();
       }
 
       //[Fact]
@@ -138,7 +129,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void HelpCommand_HelpStateNotActive_SetsHelpStateFlag()
       {
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsHelpStateActive = false
          };
@@ -153,7 +144,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool raisedEvent = false;
 
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsHelpStateActive = false
          };
@@ -168,7 +159,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void HelpCommand_HelpStateIsActive_DoesNotChangeHelpFlag()
       {
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsHelpStateActive = true
          };
@@ -183,7 +174,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool raisedEvent = false;
 
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsHelpStateActive = true
          };
@@ -268,7 +259,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void ExpandCommand_IsNotExpanded_SetsExpandedFlag()
       {
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsExpanded = false
          };
@@ -283,7 +274,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool expansionEventRaised = false;
 
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsExpanded = false
          };
@@ -298,7 +289,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void ExpandCommand_IsAlreadyExpanded_DoesNotChangeExpandedFlag()
       {
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsExpanded = true
          };
@@ -313,7 +304,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool expansionEventRaised = false;
 
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsExpanded = true
          };
@@ -328,7 +319,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void ExpandCommand_IsExitingFlagSetButIsNotExpanded_DoesNotChangeExpandedFlag()
       {
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsExiting = true,
             IsExpanded = false
@@ -344,7 +335,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool expansionEventRaised = false;
 
-         var commitViewModel = new CommitViewModel( null, null, null )
+         var commitViewModel = new CommitViewModel( null, null, null, null )
          {
             IsExiting = true,
             IsExpanded = true
@@ -369,7 +360,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object, null );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -390,7 +381,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object, null );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -412,7 +403,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object, null );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -434,7 +425,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object, null );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -456,7 +447,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object, null );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -478,7 +469,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object, null );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -502,7 +493,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object, null );
 
          viewModel.PasteCommand.Execute( null );
 

--- a/src/GitWrite/GitWrite.UnitTests/ViewModels/CommitViewModelTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/ViewModels/CommitViewModelTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using FluentAssertions;
-using GalaSoft.MvvmLight.Ioc;
 using GitWrite.Services;
 using GitWrite.ViewModels;
 using Moq;
@@ -12,7 +11,6 @@ namespace GitWrite.UnitTests.ViewModels
    {
       public CommitViewModelTests()
       {
-         SimpleIoc.Default.Reset();
          App.CommitDocument = null;
       }
 
@@ -21,7 +19,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool expanded = false;
 
-         var commitViewModel = new CommitViewModel();
+         var commitViewModel = new CommitViewModel( null, null, null );
          commitViewModel.ExpansionRequested += ( sender, e ) => expanded = true;
 
          commitViewModel.ViewLoaded();
@@ -34,7 +32,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool expanded = false;
 
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             ExtraCommitText = "Extra notes"
          };
@@ -59,7 +57,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var commitViewModel = new CommitViewModel();
+         var commitViewModel = new CommitViewModel( null, null, null );
 
          commitViewModel.ShortMessage.Should().Be( shortMessage );
       }
@@ -78,7 +76,7 @@ namespace GitWrite.UnitTests.ViewModels
 
          // Test
 
-         var commitViewModel = new CommitViewModel();
+         var commitViewModel = new CommitViewModel( null, null, null );
 
          commitViewModel.ExtraCommitText.Should().Be( longMessage );
       }
@@ -140,7 +138,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void HelpCommand_HelpStateNotActive_SetsHelpStateFlag()
       {
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsHelpStateActive = false
          };
@@ -155,7 +153,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool raisedEvent = false;
 
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsHelpStateActive = false
          };
@@ -170,7 +168,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void HelpCommand_HelpStateIsActive_DoesNotChangeHelpFlag()
       {
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsHelpStateActive = true
          };
@@ -185,7 +183,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool raisedEvent = false;
 
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsHelpStateActive = true
          };
@@ -270,7 +268,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void ExpandCommand_IsNotExpanded_SetsExpandedFlag()
       {
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsExpanded = false
          };
@@ -285,7 +283,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool expansionEventRaised = false;
 
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsExpanded = false
          };
@@ -300,7 +298,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void ExpandCommand_IsAlreadyExpanded_DoesNotChangeExpandedFlag()
       {
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsExpanded = true
          };
@@ -315,7 +313,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool expansionEventRaised = false;
 
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsExpanded = true
          };
@@ -330,7 +328,7 @@ namespace GitWrite.UnitTests.ViewModels
       [Fact]
       public void ExpandCommand_IsExitingFlagSetButIsNotExpanded_DoesNotChangeExpandedFlag()
       {
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsExiting = true,
             IsExpanded = false
@@ -346,7 +344,7 @@ namespace GitWrite.UnitTests.ViewModels
       {
          bool expansionEventRaised = false;
 
-         var commitViewModel = new CommitViewModel
+         var commitViewModel = new CommitViewModel( null, null, null )
          {
             IsExiting = true,
             IsExpanded = true
@@ -368,11 +366,10 @@ namespace GitWrite.UnitTests.ViewModels
 
          var clipboardServiceMock = new Mock<IClipboardService>();
          clipboardServiceMock.Setup( cs => cs.GetText() ).Returns( clipboardText );
-         SimpleIoc.Default.Register( () => clipboardServiceMock.Object );
 
          // Test
 
-         var viewModel = new CommitViewModel();
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -390,11 +387,10 @@ namespace GitWrite.UnitTests.ViewModels
 
          var clipboardServiceMock = new Mock<IClipboardService>();
          clipboardServiceMock.Setup( cs => cs.GetText() ).Returns( clipboardText );
-         SimpleIoc.Default.Register( () => clipboardServiceMock.Object );
 
          // Test
 
-         var viewModel = new CommitViewModel();
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -413,11 +409,10 @@ namespace GitWrite.UnitTests.ViewModels
 
          var clipboardServiceMock = new Mock<IClipboardService>();
          clipboardServiceMock.Setup( cs => cs.GetText() ).Returns( clipboardText );
-         SimpleIoc.Default.Register( () => clipboardServiceMock.Object );
 
          // Test
 
-         var viewModel = new CommitViewModel();
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -436,11 +431,10 @@ namespace GitWrite.UnitTests.ViewModels
 
          var clipboardServiceMock = new Mock<IClipboardService>();
          clipboardServiceMock.Setup( cs => cs.GetText() ).Returns( clipboardText );
-         SimpleIoc.Default.Register( () => clipboardServiceMock.Object );
 
          // Test
 
-         var viewModel = new CommitViewModel();
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -459,11 +453,10 @@ namespace GitWrite.UnitTests.ViewModels
 
          var clipboardServiceMock = new Mock<IClipboardService>();
          clipboardServiceMock.Setup( cs => cs.GetText() ).Returns( clipboardText );
-         SimpleIoc.Default.Register( () => clipboardServiceMock.Object );
 
          // Test
 
-         var viewModel = new CommitViewModel();
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -482,11 +475,10 @@ namespace GitWrite.UnitTests.ViewModels
 
          var clipboardServiceMock = new Mock<IClipboardService>();
          clipboardServiceMock.Setup( cs => cs.GetText() ).Returns( clipboardText );
-         SimpleIoc.Default.Register( () => clipboardServiceMock.Object );
 
          // Test
 
-         var viewModel = new CommitViewModel();
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
 
          viewModel.PasteCommand.Execute( null );
 
@@ -507,11 +499,10 @@ namespace GitWrite.UnitTests.ViewModels
 
          var clipboardServiceMock = new Mock<IClipboardService>();
          clipboardServiceMock.Setup( cs => cs.GetText() ).Returns( clipboardText );
-         SimpleIoc.Default.Register( () => clipboardServiceMock.Object );
 
          // Test
 
-         var viewModel = new CommitViewModel();
+         var viewModel = new CommitViewModel( null, null, clipboardServiceMock.Object );
 
          viewModel.PasteCommand.Execute( null );
 

--- a/src/GitWrite/GitWrite.UnitTests/ViewModels/CommitViewModelTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/ViewModels/CommitViewModelTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using FluentAssertions;
-using GitWrite.Services;
-using GitWrite.ViewModels;
 using Moq;
 using Xunit;
+using GitWrite.Services;
+using GitWrite.ViewModels;
 
 namespace GitWrite.UnitTests.ViewModels
 {

--- a/src/GitWrite/GitWrite.UnitTests/ViewModels/GitWriteViewModelBaseTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/ViewModels/GitWriteViewModelBaseTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using FluentAssertions;
-using GalaSoft.MvvmLight.Ioc;
 using GitWrite.Services;
 using GitWrite.ViewModels;
 using Moq;
@@ -10,22 +9,16 @@ namespace GitWrite.UnitTests.ViewModels
 {
    public class GitWriteViewModelBaseTests
    {
-      public GitWriteViewModelBaseTests()
-      {
-         SimpleIoc.Default.Reset();
-      }
-
       [Fact]
       public void AbortCommand_DoesNotNeedConfirmation_ShutsDownTheApp()
       {
          // Setup
 
          var appServiceMock = new Mock<IAppService>();
-         SimpleIoc.Default.Register( () => appServiceMock.Object );
 
          // Test
 
-         var viewModel = new GitWriteViewModelBase();
+         var viewModel = new GitWriteViewModelBase( null, appServiceMock.Object );
 
          viewModel.AbortCommand.Execute( null );
 
@@ -42,11 +35,10 @@ namespace GitWrite.UnitTests.ViewModels
          // Setup
 
          var appServiceMock = new Mock<IAppService>();
-         SimpleIoc.Default.Register( () => appServiceMock.Object );
 
          // Test
 
-         var viewModel = new GitWriteViewModelBase();
+         var viewModel = new GitWriteViewModelBase( null, appServiceMock.Object );
 
          viewModel.ShutdownRequested += ( sender, e ) =>
          {

--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -48,12 +48,14 @@ namespace GitWrite
       private void InitializeDependencies()
       {
          ServiceLocator.SetLocatorProvider( () => SimpleIoc.Default );
-         SimpleIoc.Default.Register<CommitViewModel>();
+
+         var appService = new AppService();
+
+         SimpleIoc.Default.Register( () => new CommitViewModel( SimpleIoc.Default.GetInstance<IViewService>(), appService, new ClipboardService() ) );
          SimpleIoc.Default.Register<InteractiveRebaseViewModel>();
          SimpleIoc.Default.Register<IRegistryService, RegistryService>();
          SimpleIoc.Default.Register<IApplicationSettings>( () => new ApplicationSettings( new RegistryService() ) );
          SimpleIoc.Default.Register<IAppService, AppService>();
-         SimpleIoc.Default.Register<IClipboardService, ClipboardService>();
          SimpleIoc.Default.Register<IEnvironmentAdapter, EnvironmentAdapter>();
          SimpleIoc.Default.Register<ICommitFileReader>( () => new CommitFileReader( new FileAdapter() ) );
          SimpleIoc.Default.Register<IFileAdapter, FileAdapter>();

--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -26,7 +26,7 @@ namespace GitWrite
 
          // Load the commit file
 
-         var appController = new AppController( new EnvironmentAdapter(), new CommitFileReader( new FileAdapter() ) );
+         var appController = new AppController( new EnvironmentAdapter(), SimpleIoc.Default.GetInstance<ICommitFileReader>() );
 
          appController.Start( e.Args );
 
@@ -49,16 +49,10 @@ namespace GitWrite
       {
          ServiceLocator.SetLocatorProvider( () => SimpleIoc.Default );
 
-         var appService = new AppService();
-
-         SimpleIoc.Default.Register( () => new CommitViewModel( SimpleIoc.Default.GetInstance<IViewService>(), appService, new ClipboardService() ) );
+         SimpleIoc.Default.Register( () => new CommitViewModel( SimpleIoc.Default.GetInstance<IViewService>(), new AppService(), new ClipboardService() ) );
          SimpleIoc.Default.Register<InteractiveRebaseViewModel>();
-         SimpleIoc.Default.Register<IRegistryService, RegistryService>();
          SimpleIoc.Default.Register<IApplicationSettings>( () => new ApplicationSettings( new RegistryService() ) );
-         SimpleIoc.Default.Register<IAppService, AppService>();
-         SimpleIoc.Default.Register<IEnvironmentAdapter, EnvironmentAdapter>();
          SimpleIoc.Default.Register<ICommitFileReader>( () => new CommitFileReader( new FileAdapter() ) );
-         SimpleIoc.Default.Register<IFileAdapter, FileAdapter>();
          SimpleIoc.Default.Register<IStoryboardHelper, StoryboardHelper>();
       }
 

--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -26,7 +26,7 @@ namespace GitWrite
 
          // Load the commit file
 
-         var appController = new AppController();
+         var appController = new AppController( new EnvironmentAdapter(), new CommitFileReader( new FileAdapter() ) );
 
          appController.Start( e.Args );
 

--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -28,7 +28,7 @@ namespace GitWrite
 
          var appController = new AppController( new EnvironmentAdapter(), SimpleIoc.Default.GetInstance<ICommitFileReader>() );
 
-         appController.Start( e.Args );
+         App.CommitDocument = appController.Start( e.Args );
 
          // Set the startup UI and we're off
 

--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -51,7 +51,7 @@ namespace GitWrite
          SimpleIoc.Default.Register<CommitViewModel>();
          SimpleIoc.Default.Register<InteractiveRebaseViewModel>();
          SimpleIoc.Default.Register<IRegistryService, RegistryService>();
-         SimpleIoc.Default.Register<IApplicationSettings, ApplicationSettings>();
+         SimpleIoc.Default.Register<IApplicationSettings>( () => new ApplicationSettings( new RegistryService() ) );
          SimpleIoc.Default.Register<IAppService, AppService>();
          SimpleIoc.Default.Register<IClipboardService, ClipboardService>();
          SimpleIoc.Default.Register<IEnvironmentAdapter, EnvironmentAdapter>();

--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -55,7 +55,7 @@ namespace GitWrite
          SimpleIoc.Default.Register<IAppService, AppService>();
          SimpleIoc.Default.Register<IClipboardService, ClipboardService>();
          SimpleIoc.Default.Register<IEnvironmentAdapter, EnvironmentAdapter>();
-         SimpleIoc.Default.Register<ICommitFileReader, CommitFileReader>();
+         SimpleIoc.Default.Register<ICommitFileReader>( () => new CommitFileReader( new FileAdapter() ) );
          SimpleIoc.Default.Register<IFileAdapter, FileAdapter>();
          SimpleIoc.Default.Register<IStoryboardHelper, StoryboardHelper>();
       }

--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -13,12 +13,6 @@ namespace GitWrite
 {
    public partial class App : Application
    {
-      public static ICommitDocument CommitDocument
-      {
-         get;
-         set;
-      }
-
       private void Application_OnStartup( object sender, StartupEventArgs e )
       {
          InitializeDependencies();
@@ -27,8 +21,9 @@ namespace GitWrite
          // Load the commit file
 
          var appController = new AppController( new EnvironmentAdapter(), SimpleIoc.Default.GetInstance<ICommitFileReader>() );
+         var commitDocument = appController.Start( e.Args );
 
-         App.CommitDocument = appController.Start( e.Args );
+         SimpleIoc.Default.Register<ICommitDocument>( () => commitDocument );
 
          // Set the startup UI and we're off
 
@@ -49,7 +44,6 @@ namespace GitWrite
       {
          ServiceLocator.SetLocatorProvider( () => SimpleIoc.Default );
 
-         SimpleIoc.Default.Register( () => new CommitViewModel( SimpleIoc.Default.GetInstance<IViewService>(), new AppService(), new ClipboardService() ) );
          SimpleIoc.Default.Register<InteractiveRebaseViewModel>();
          SimpleIoc.Default.Register<IApplicationSettings>( () => new ApplicationSettings( new RegistryService() ) );
          SimpleIoc.Default.Register<ICommitFileReader>( () => new CommitFileReader( new FileAdapter() ) );

--- a/src/GitWrite/GitWrite/AppController.cs
+++ b/src/GitWrite/GitWrite/AppController.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using GitWrite.Views;
 
@@ -21,12 +22,12 @@ namespace GitWrite
          _commitFileReader = commitFileReader;
       }
 
-      public void Start( string[] arguments )
+      public CommitDocument Start( string[] arguments )
       {
          if ( arguments == null || arguments.Length == 0 )
          {
             _environmentAdapter.Exit( 1 );
-            return;
+            return null;
          }
 
          string fileName = Path.GetFileName( arguments[0] );
@@ -35,17 +36,21 @@ namespace GitWrite
          if ( ApplicationMode == ApplicationMode.Unknown )
          {
             _environmentAdapter.Exit( 1 );
-            return;
+            return null;
          }
+
+         CommitDocument commitDocument = null;
 
          try
          {
-            App.CommitDocument = _commitFileReader.FromFile( arguments[0] );
+            commitDocument = _commitFileReader.FromFile( arguments[0] );
          }
          catch ( GitFileLoadException )
          {
             _environmentAdapter.Exit( 1 );
          }
+
+         return commitDocument;
       }
 
       public async Task ShutDownAsync( ExitReason exitReason )

--- a/src/GitWrite/GitWrite/AppController.cs
+++ b/src/GitWrite/GitWrite/AppController.cs
@@ -1,26 +1,31 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
-using GalaSoft.MvvmLight.Ioc;
 using GitWrite.Views;
 
 namespace GitWrite
 {
    public class AppController : IAppController
    {
+      private readonly IEnvironmentAdapter _environmentAdapter;
+      private readonly ICommitFileReader _commitFileReader;
+
       public ApplicationMode ApplicationMode
       {
          get;
          private set;
       }
 
+      public AppController( IEnvironmentAdapter environmentAdapter, ICommitFileReader commitFileReader )
+      {
+         _environmentAdapter = environmentAdapter;
+         _commitFileReader = commitFileReader;
+      }
+
       public void Start( string[] arguments )
       {
          if ( arguments == null || arguments.Length == 0 )
          {
-            var environmentAdapter = SimpleIoc.Default.GetInstance<IEnvironmentAdapter>();
-
-            environmentAdapter.Exit( 1 );
-
+            _environmentAdapter.Exit( 1 );
             return;
          }
 
@@ -29,24 +34,17 @@ namespace GitWrite
 
          if ( ApplicationMode == ApplicationMode.Unknown )
          {
-            var environmentAdapter = SimpleIoc.Default.GetInstance<IEnvironmentAdapter>();
-
-            environmentAdapter.Exit( 1 );
-
+            _environmentAdapter.Exit( 1 );
             return;
          }
 
-         var commitFileReader = SimpleIoc.Default.GetInstance<ICommitFileReader>();
-
          try
          {
-            App.CommitDocument = commitFileReader.FromFile( arguments[0] );
+            App.CommitDocument = _commitFileReader.FromFile( arguments[0] );
          }
          catch ( GitFileLoadException )
          {
-            var environmentAdapter = SimpleIoc.Default.GetInstance<IEnvironmentAdapter>();
-
-            environmentAdapter.Exit( 1 );
+            _environmentAdapter.Exit( 1 );
          }
       }
 

--- a/src/GitWrite/GitWrite/CommitDocument.cs
+++ b/src/GitWrite/GitWrite/CommitDocument.cs
@@ -1,9 +1,9 @@
-﻿using GalaSoft.MvvmLight.Ioc;
-
-namespace GitWrite
+﻿namespace GitWrite
 {
    public class CommitDocument : ICommitDocument
    {
+      private readonly IFileAdapter _fileAdapter;
+
       public string Name
       {
          get;
@@ -28,6 +28,11 @@ namespace GitWrite
          set;
       }
 
+      public CommitDocument( IFileAdapter fileAdapter )
+      {
+         _fileAdapter = fileAdapter;
+      }
+
       public void Save()
       {
          var lines = new[]
@@ -37,18 +42,13 @@ namespace GitWrite
             LongMessage
          };
 
-         var fileAdapter = SimpleIoc.Default.GetInstance<IFileAdapter>();
-
-         fileAdapter.WriteAllLines( Name, lines );
+         _fileAdapter.WriteAllLines( Name, lines );
       }
 
       public void Clear()
       {
-         var fileAdapter = SimpleIoc.Default.GetInstance<IFileAdapter>();
-
-         fileAdapter.Delete( Name );
-
-         fileAdapter.Create( Name );
+         _fileAdapter.Delete( Name );
+         _fileAdapter.Create( Name );
       }
    }
 }

--- a/src/GitWrite/GitWrite/CommitFileReader.cs
+++ b/src/GitWrite/GitWrite/CommitFileReader.cs
@@ -1,11 +1,15 @@
 ﻿using System;
-using GalaSoft.MvvmLight.Ioc;
 
 namespace GitWrite
 {
    public class CommitFileReader : ICommitFileReader
    {
-      private readonly IFileAdapter _fileAdapter = SimpleIoc.Default.GetInstance<IFileAdapter>();
+      private readonly IFileAdapter _fileAdapter;
+
+      public CommitFileReader( IFileAdapter fileAdapter )
+      {
+         _fileAdapter = fileAdapter;
+      }
 
       public CommitDocument FromFile( string path )
       {

--- a/src/GitWrite/GitWrite/CommitFileReader.cs
+++ b/src/GitWrite/GitWrite/CommitFileReader.cs
@@ -39,7 +39,7 @@ namespace GitWrite
 
       private CommitDocument CreateBasicDocument( string path )
       {
-         return new CommitDocument
+         return new CommitDocument( _fileAdapter )
          {
             RawLines = _fileAdapter.ReadAllLines( path ),
             Name = path

--- a/src/GitWrite/GitWrite/Services/ApplicationSettings.cs
+++ b/src/GitWrite/GitWrite/Services/ApplicationSettings.cs
@@ -1,24 +1,21 @@
-﻿using System;
-using GalaSoft.MvvmLight.Ioc;
-using Microsoft.Win32;
+﻿using Microsoft.Win32;
 
 namespace GitWrite.Services
 {
    public class ApplicationSettings : IApplicationSettings
    {
       private const string _path = @"SOFTWARE\GitWrite";
-      private readonly Lazy<IRegistryService> _registryLazy = new Lazy<IRegistryService>( () => SimpleIoc.Default.GetInstance<IRegistryService>() );
-      private IRegistryService RegistryService => _registryLazy.Value;
+      private readonly IRegistryService _registryService;
 
       public string Theme
       {
          get
          {
-            return RegistryService.ReadString( Registry.CurrentUser, _path, nameof( Theme ) );
+            return _registryService.ReadString( Registry.CurrentUser, _path, nameof( Theme ) );
          }
          set
          {
-            RegistryService.WriteString( Registry.CurrentUser, _path, nameof( Theme ), value );
+            _registryService.WriteString( Registry.CurrentUser, _path, nameof( Theme ), value );
          }
       }
 
@@ -26,11 +23,11 @@ namespace GitWrite.Services
       {
          get
          {
-            return RegistryService.ReadInt( Registry.CurrentUser, _path, nameof( WindowX ) );
+            return _registryService.ReadInt( Registry.CurrentUser, _path, nameof( WindowX ) );
          }
          set
          {
-            RegistryService.WriteInt( Registry.CurrentUser, _path, nameof( WindowX ), value );
+            _registryService.WriteInt( Registry.CurrentUser, _path, nameof( WindowX ), value );
          }
       }
 
@@ -38,12 +35,17 @@ namespace GitWrite.Services
       {
          get
          {
-            return RegistryService.ReadInt( Registry.CurrentUser, _path, nameof( WindowY ) );
+            return _registryService.ReadInt( Registry.CurrentUser, _path, nameof( WindowY ) );
          }
          set
          {
-            RegistryService.WriteInt( Registry.CurrentUser, _path, nameof( WindowY ), value );
+            _registryService.WriteInt( Registry.CurrentUser, _path, nameof( WindowY ), value );
          }
+      }
+
+      public ApplicationSettings( IRegistryService registryService )
+      {
+         _registryService = registryService;
       }
    }
 }

--- a/src/GitWrite/GitWrite/ViewModels/CommitViewModel.cs
+++ b/src/GitWrite/GitWrite/ViewModels/CommitViewModel.cs
@@ -47,6 +47,11 @@ namespace GitWrite.ViewModels
          get;
       }
 
+      public ICommitDocument CommitDocument
+      {
+         get;
+      }
+
       public CommitInputState InputState
       {
          get;
@@ -127,10 +132,11 @@ namespace GitWrite.ViewModels
       public event EventHandler HelpRequested;
       public event EventHandler CollapseHelpRequested;
        
-      public CommitViewModel( IViewService viewService, IAppService appService, IClipboardService clipboardService )
+      public CommitViewModel( IViewService viewService, IAppService appService, IClipboardService clipboardService, ICommitDocument commitDocument )
          : base( viewService, appService )
       {
          _clipboardService = clipboardService;
+         CommitDocument = commitDocument;
 
          PrimaryMessageGotFocusCommand = new RelayCommand( () => ControlState = CommitControlState.EditingPrimaryMessage );
          SecondaryNotesGotFocusCommand = new RelayCommand( ExpandUI );
@@ -140,8 +146,8 @@ namespace GitWrite.ViewModels
          SaveCommand = new RelayCommand( async () => await OnSaveAsync() );
          PasteCommand = new RelayCommand( PasteFromClipboard );
 
-         ShortMessage = App.CommitDocument?.ShortMessage;
-         ExtraCommitText = App.CommitDocument?.LongMessage;
+         ShortMessage = CommitDocument?.ShortMessage;
+         ExtraCommitText = CommitDocument?.LongMessage;
 
          IsDirty = false;
       }
@@ -171,10 +177,9 @@ namespace GitWrite.ViewModels
 
          var shutdownTask = OnShutdownRequested( this, new ShutdownEventArgs( ExitReason.Accept ) );
 
-         App.CommitDocument.ShortMessage = ShortMessage;
-         App.CommitDocument.LongMessage = ExtraCommitText;
-
-         App.CommitDocument.Save();
+         CommitDocument.ShortMessage = ShortMessage;
+         CommitDocument.LongMessage = ExtraCommitText;
+         CommitDocument.Save();
 
          await shutdownTask;
 

--- a/src/GitWrite/GitWrite/ViewModels/CommitViewModel.cs
+++ b/src/GitWrite/GitWrite/ViewModels/CommitViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using GalaSoft.MvvmLight.Command;
-using GalaSoft.MvvmLight.Ioc;
 using GitWrite.Services;
 using GitWrite.Views;
 
@@ -10,6 +9,8 @@ namespace GitWrite.ViewModels
 {
    public class CommitViewModel : GitWriteViewModelBase
    {
+      private readonly IClipboardService _clipboardService;
+
       public RelayCommand PrimaryMessageGotFocusCommand
       {
          get;
@@ -126,8 +127,11 @@ namespace GitWrite.ViewModels
       public event EventHandler HelpRequested;
       public event EventHandler CollapseHelpRequested;
        
-      public CommitViewModel()
+      public CommitViewModel( IViewService viewService, IAppService appService, IClipboardService clipboardService )
+         : base( viewService, appService )
       {
+         _clipboardService = clipboardService;
+
          PrimaryMessageGotFocusCommand = new RelayCommand( () => ControlState = CommitControlState.EditingPrimaryMessage );
          SecondaryNotesGotFocusCommand = new RelayCommand( ExpandUI );
          ExpandCommand = new RelayCommand( ExpandUI );
@@ -174,8 +178,7 @@ namespace GitWrite.ViewModels
 
          await shutdownTask;
 
-         var appService = SimpleIoc.Default.GetInstance<IAppService>();
-         appService.Shutdown();
+         AppService.Shutdown();
       }
 
       protected override async Task OnDiscardAsync()
@@ -215,8 +218,7 @@ namespace GitWrite.ViewModels
 
       private void PasteFromClipboard()
       {
-         var clipboard = SimpleIoc.Default.GetInstance<IClipboardService>();
-         string clipboardText = clipboard.GetText();
+         string clipboardText = _clipboardService.GetText();
 
          if ( !string.IsNullOrEmpty( clipboardText ) )
          {

--- a/src/GitWrite/GitWrite/ViewModels/GitWriteViewModelBase.cs
+++ b/src/GitWrite/GitWrite/ViewModels/GitWriteViewModelBase.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Command;
-using GalaSoft.MvvmLight.Ioc;
 using GitWrite.Services;
 using GitWrite.Views;
 using GitWrite.Views.Controls;
@@ -10,6 +9,16 @@ namespace GitWrite.ViewModels
 {
    public class GitWriteViewModelBase : ViewModelBase
    {
+      protected IViewService ViewService
+      {
+         get;
+      }
+
+      protected IAppService AppService
+      {
+         get;
+      }
+
       public bool IsDirty
       {
          get;
@@ -58,8 +67,11 @@ namespace GitWrite.ViewModels
          }
       } 
 
-      public GitWriteViewModelBase()
+      public GitWriteViewModelBase( IViewService viewService, IAppService appService )
       {
+         ViewService = viewService;
+         AppService = appService;
+
          AbortCommand = new RelayCommand( OnAbort );
       }
 
@@ -76,8 +88,7 @@ namespace GitWrite.ViewModels
          {
             IsConfirming = true;
 
-            var viewService = SimpleIoc.Default.GetInstance<IViewService>();
-            var confirmationResult = await viewService.ConfirmExitAsync();
+            var confirmationResult = await ViewService.ConfirmExitAsync();
 
             if ( confirmationResult == ConfirmationResult.Cancel )
             {
@@ -105,8 +116,7 @@ namespace GitWrite.ViewModels
          IsExiting = true;
          await OnShutdownRequested( this, new ShutdownEventArgs( exitReason ) );
 
-         var appService = SimpleIoc.Default.GetInstance<IAppService>();
-         appService.Shutdown();
+         AppService.Shutdown();
       }
 
       protected virtual Task OnSaveAsync()

--- a/src/GitWrite/GitWrite/ViewModels/InteractiveRebaseViewModel.cs
+++ b/src/GitWrite/GitWrite/ViewModels/InteractiveRebaseViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using GitWrite.Services;
 
 namespace GitWrite.ViewModels
 {
@@ -9,7 +10,8 @@ namespace GitWrite.ViewModels
          get;
       }
 
-      public InteractiveRebaseViewModel()
+      public InteractiveRebaseViewModel( IViewService viewService, IAppService appService )
+         : base ( viewService, appService )
       {
          Items = new ObservableCollection<RebaseItem>
          {

--- a/src/GitWrite/GitWrite/ViewModels/ViewModelLocator.cs
+++ b/src/GitWrite/GitWrite/ViewModels/ViewModelLocator.cs
@@ -1,10 +1,14 @@
+using GalaSoft.MvvmLight.Ioc;
+using GitWrite.Services;
 using Microsoft.Practices.ServiceLocation;
 
 namespace GitWrite.ViewModels
 {
    public class ViewModelLocator
    {
-      public CommitViewModel CommitViewModel => ServiceLocator.Current.GetInstance<CommitViewModel>();
+      public CommitViewModel CommitViewModel
+         => new CommitViewModel( SimpleIoc.Default.GetInstance<IViewService>(), new AppService(), new ClipboardService(), SimpleIoc.Default.GetInstance<ICommitDocument>() );
+
       public InteractiveRebaseViewModel InteractiveRebaseViewMdoel => ServiceLocator.Current.GetInstance<InteractiveRebaseViewModel>();
 
       public static void Cleanup()


### PR DESCRIPTION
Moving it all around to deal more in constructor injection. With the move to xUnit, it really prefers to run the tests in parallel, which really screws up the static DI container. Having dependencies be instance properties delivered by constructors, there's suddenly no reliance on a static container, and parallelism becomes possible.