### PR TITLE
Can no longer press Enter to accept an empty commit

### DIFF
--- a/src/GitWrite/GitWrite/ViewModels/CommitViewModel.cs
+++ b/src/GitWrite/GitWrite/ViewModels/CommitViewModel.cs
@@ -50,7 +50,7 @@ namespace GitWrite.ViewModels
          set;
       }
 
-      public string Title => $"Commiting to {_gitService.GetCurrentBranchName()}";
+      public string Title => null;// $"Commiting to {_gitService.GetCurrentBranchName()}";
 
       private string _shortMessage;
       public string ShortMessage
@@ -152,11 +152,11 @@ namespace GitWrite.ViewModels
 
       protected virtual Task OnExitRequestedAsync( object sender, EventArgs e ) => AsyncExitRequested?.Invoke( sender, e );
 
-      protected override Task OnSaveAsync()
+      protected override Task<bool> OnSaveAsync()
       {
          if ( string.IsNullOrWhiteSpace( ShortMessage ) || IsExiting )
          {
-            return Task.FromResult( true );
+            return Task.FromResult( false );
          }
 
          _commitDocument.ShortMessage = ShortMessage;

--- a/src/GitWrite/GitWrite/ViewModels/GitWriteViewModelBase.cs
+++ b/src/GitWrite/GitWrite/ViewModels/GitWriteViewModelBase.cs
@@ -134,7 +134,12 @@ namespace GitWrite.ViewModels
       private async void OnSave()
       {
          ExitReason = ExitReason.Save;
-         await OnSaveAsync();
+         bool shouldContinue = await OnSaveAsync();
+
+         if ( !shouldContinue )
+         {
+            return;
+         }
 
          IsExiting = true;
          await OnShutdownRequested( this, new ShutdownEventArgs( ExitReason.Save ) );
@@ -142,7 +147,7 @@ namespace GitWrite.ViewModels
          AppService.Shutdown();
       }
 
-      protected virtual Task OnSaveAsync()
+      protected virtual Task<bool> OnSaveAsync()
       {
          return Task.FromResult( true );
       }

--- a/src/GitWrite/GitWrite/ViewModels/InteractiveRebaseViewModel.cs
+++ b/src/GitWrite/GitWrite/ViewModels/InteractiveRebaseViewModel.cs
@@ -31,7 +31,7 @@ namespace GitWrite.ViewModels
          Items.Insert( indexTwo, tempItem );
       }
 
-      protected override Task OnSaveAsync()
+      protected override Task<bool> OnSaveAsync()
       {
          _document.RebaseItems = Items.ToArray();
          _document.Save();


### PR DESCRIPTION
This got broken somewhere along the way. OnSaveAsync now returns a boolean to indicate if it should continue to save (false to abort). Gives specific workflows an opportunity to abort based on their custom rules.