### PR TITLE
Temporarily disabling the smart paste command

### DIFF
--- a/src/GitWrite/GitWrite/Behaviors/CommitKeyPressBehavior.cs
+++ b/src/GitWrite/GitWrite/Behaviors/CommitKeyPressBehavior.cs
@@ -47,11 +47,11 @@ namespace GitWrite.Behaviors
 
       private void PreviewKeyDown( object sender, KeyEventArgs e )
       {
-         if ( e.Key == Key.V && Keyboard.Modifiers == ModifierKeys.Control )
-         {
-            _viewModel.PasteCommand.Execute( null );
-         }
-         else if ( e.Key == Key.T && Keyboard.Modifiers == ModifierKeys.Control )
+         //if ( e.Key == Key.V && Keyboard.Modifiers == ModifierKeys.Control )
+         //{
+         //   _viewModel.PasteCommand.Execute( null );
+         //}
+         if ( e.Key == Key.T && Keyboard.Modifiers == ModifierKeys.Control )
          {
             ThemeSwitcher.SwitchToNext();
 

--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
@@ -55,11 +55,11 @@ namespace GitWrite.Views
 
       private void CommitWindow_OnPreviewCanExecute( object sender, CanExecuteRoutedEventArgs e )
       {
-         if ( e.Command == ApplicationCommands.Paste )
-         {
-            e.CanExecute = false;
-            e.Handled = true;
-         }
+         //if ( e.Command == ApplicationCommands.Paste )
+         //{
+         //   e.CanExecute = false;
+         //   e.Handled = true;
+         //}
       }
    }
 }


### PR DESCRIPTION
It wasn't perfect and was getting in the way of actually using the app. Commenting it out in lieu of a proper feature switch.