### PR TITLE
Now collapses the UI on commit

### DIFF
--- a/src/GitWrite/GitWrite/ViewModels/CommitViewModel.cs
+++ b/src/GitWrite/GitWrite/ViewModels/CommitViewModel.cs
@@ -159,6 +159,8 @@ namespace GitWrite.ViewModels
             return Task.FromResult( false );
          }
 
+         CollapseUI();
+
          _commitDocument.ShortMessage = ShortMessage;
          _commitDocument.LongMessage = ExtraCommitText;
          _commitDocument.Save();


### PR DESCRIPTION
Previously this didn't collapse the extra notes section on commit. It did on DISCARD, but not commit.