### PR TITLE
Now fades in the UI on launch

### DIFF
--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml
@@ -17,7 +17,8 @@
    WindowStyle="None"
    FocusManager.FocusedElement="{Binding ElementName=MainEntryBox}"
    CommandManager.PreviewCanExecute="CommitWindow_OnPreviewCanExecute"
-   DataContext="{Binding CommitViewModel, Source={StaticResource ViewModelLocator}}">
+   DataContext="{Binding CommitViewModel, Source={StaticResource ViewModelLocator}}"
+   Loaded="CommitWindow_OnLoaded">
 
    <Window.Resources>
       <ResourceDictionary>

--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
@@ -25,6 +25,24 @@ namespace GitWrite.Views
          _viewModel.AsyncExitRequested += OnAsyncExitRequested;
       }
 
+      private void CommitWindow_OnLoaded( object sender, RoutedEventArgs e )
+      {
+         Opacity = 0;
+
+         const double duration = 100;
+
+         var storyboard = new Storyboard();
+
+         var opacityAnimation = new DoubleAnimation( 0, 1, new Duration( TimeSpan.FromMilliseconds( duration ) ) );
+
+         storyboard.Children.Add( opacityAnimation );
+
+         Storyboard.SetTargetProperty( opacityAnimation, new PropertyPath( nameof( Opacity ) ) );
+         Storyboard.SetTarget( opacityAnimation, this );
+
+         storyboard.Begin();
+      }
+
       private Task OnAsyncExitRequested( object sender, ShutdownEventArgs e )
       {
          if ( _viewModel.IsExiting )

--- a/src/GitWrite/GitWrite/Views/WindowBase.cs
+++ b/src/GitWrite/GitWrite/Views/WindowBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interactivity;
 using GalaSoft.MvvmLight.Ioc;
@@ -29,6 +30,8 @@ namespace GitWrite.Views
       private async void OnLoaded( object sender, EventArgs e )
       {
          _viewModel = (GitWriteViewModelBase) DataContext;
+
+         await Task.Delay( 200 );
 
          var materialGenerator = new MaterialGenerator( this );
          await materialGenerator.GenerateAsync();


### PR DESCRIPTION
Also delays the material generation since it seems to choke up the UI thread. Now we fade in (while delaying materials), and then that resumes. We should do some kind of signaling over this arbitrary delay.