### PR TITLE
Caret now appears at the end when amending, instead of JUMPING there

### DIFF
--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
@@ -27,6 +27,9 @@ namespace GitWrite.Views
 
       private void CommitWindow_OnLoaded( object sender, RoutedEventArgs e )
       {
+         MainEntryBox.HideCaret();
+         MainEntryBox.MoveCaretToEnd();
+
          Opacity = 0;
 
          const double duration = 100;
@@ -36,6 +39,7 @@ namespace GitWrite.Views
          var opacityAnimation = new DoubleAnimation( 0, 1, new Duration( TimeSpan.FromMilliseconds( duration ) ) );
 
          storyboard.Children.Add( opacityAnimation );
+         storyboard.Completed += ( _, __ ) => MainEntryBox.ShowCaret();
 
          Storyboard.SetTargetProperty( opacityAnimation, new PropertyPath( nameof( Opacity ) ) );
          Storyboard.SetTarget( opacityAnimation, this );

--- a/src/GitWrite/GitWrite/Views/Controls/MainEntryBox.xaml.cs
+++ b/src/GitWrite/GitWrite/Views/Controls/MainEntryBox.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Media;
 
@@ -34,6 +35,10 @@ namespace GitWrite.Views.Controls
          InitializeComponent();
          LayoutRoot.DataContext = this;
       }
+
+      public void HideCaret() => PrimaryTextBox.CaretBrush = new SolidColorBrush( Colors.Transparent );
+      public void ShowCaret() => PrimaryTextBox.ClearValue( TextBoxBase.CaretBrushProperty );
+      public void MoveCaretToEnd() => PrimaryTextBox.SelectionStart = PrimaryTextBox.Text.Length;
 
       public void HideRadialText() => RadialCounter.TextColor = Colors.Transparent;
 


### PR DESCRIPTION
Kind of cheats--hides the caret during load, moves it, and replaces it after the animation completes. It happens fast enough such that it doesn't look laggy.