### PR TITLE
Refactoring out the use of 72 as the character limit

### DIFF
--- a/src/GitWrite/GitWrite.UnitTests/Views/Converters/StringLengthToProgressConverterTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/Views/Converters/StringLengthToProgressConverterTests.cs
@@ -1,5 +1,7 @@
 ﻿using Xunit;
 using FluentAssertions;
+using Moq;
+using GitWrite.Services;
 using GitWrite.Views.Converters;
 
 namespace GitWrite.UnitTests.Views.Converters
@@ -9,9 +11,17 @@ namespace GitWrite.UnitTests.Views.Converters
       [Fact]
       public void Convert_PassesNullValue_ReturnsZero()
       {
-         var converter = new StringLengthToProgressConverter();
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+
+         // Act
+
+         var converter = new StringLengthToProgressConverter( appSettingsMock.Object );
 
          double progress = (double) converter.Convert( null, null, null, null );
+
+         // Assert
 
          progress.Should().Be( 0.0 );
       }
@@ -19,9 +29,17 @@ namespace GitWrite.UnitTests.Views.Converters
       [Fact]
       public void Convert_PassesInEmptyString_ReturnsZero()
       {
-         var converter = new StringLengthToProgressConverter();
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+
+         // Act
+
+         var converter = new StringLengthToProgressConverter( appSettingsMock.Object );
 
          double progress = (double) converter.Convert( string.Empty, null, null, null );
+
+         // Assert
 
          progress.Should().Be( 0.0 );
       }
@@ -29,9 +47,17 @@ namespace GitWrite.UnitTests.Views.Converters
       [Fact]
       public void Convert_PassesUnparsableString_ReturnsZero()
       {
-         var converter = new StringLengthToProgressConverter();
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+
+         // Act
+
+         var converter = new StringLengthToProgressConverter( appSettingsMock.Object );
 
          double progress = (double) converter.Convert( "NotAnInteger", null, null, null );
+
+         // Assert
 
          progress.Should().Be( 0.0 );
       }
@@ -39,7 +65,16 @@ namespace GitWrite.UnitTests.Views.Converters
       [Fact]
       public void Convert_PassesStringWithZeroInteger_ReturnsProgressValue()
       {
-         var converter = new StringLengthToProgressConverter();
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+         appSettingsMock.SetupGet( @as => @as.MaxCommitLength ).Returns( 72 );
+
+         // Act
+
+         var converter = new StringLengthToProgressConverter( appSettingsMock.Object );
+
+         // Assert
 
          double progress = (double) converter.Convert( "0", null, null, null );
 
@@ -49,9 +84,20 @@ namespace GitWrite.UnitTests.Views.Converters
       [Fact]
       public void Convert_PassesStringWith72Integer_ReturnsProgressValue()
       {
-         var converter = new StringLengthToProgressConverter();
+         const int maxLength = 72;
 
-         double progress = (double) converter.Convert( "72", null, null, null );
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+         appSettingsMock.SetupGet( @as => @as.MaxCommitLength ).Returns( maxLength );
+
+         // Act
+
+         var converter = new StringLengthToProgressConverter( appSettingsMock.Object );
+
+         double progress = (double) converter.Convert( maxLength.ToString(), null, null, null );
+
+         // Assert
 
          progress.Should().Be( 1.0 );
       }

--- a/src/GitWrite/GitWrite.UnitTests/Views/Converters/TextLengthInversionConverterTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/Views/Converters/TextLengthInversionConverterTests.cs
@@ -1,6 +1,8 @@
 ﻿using FluentAssertions;
-using GitWrite.Views.Converters;
+using Moq;
 using Xunit;
+using GitWrite.Services;
+using GitWrite.Views.Converters;
 
 namespace GitWrite.UnitTests.Views.Converters
 {
@@ -9,19 +11,41 @@ namespace GitWrite.UnitTests.Views.Converters
       [Fact]
       public void Convert_InputIsZero_ConvertsToMaxOf72()
       {
-         var converter = new TextLengthInversionConverter();
+         const int maxLength = 72;
+
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+         appSettingsMock.SetupGet( @as => @as.MaxCommitLength ).Returns( maxLength );
+
+         // Act
+
+         var converter = new TextLengthInversionConverter( appSettingsMock.Object );
 
          int invertedLength = (int) converter.Convert( 0, null, null, null );
 
-         invertedLength.Should().Be( 72 );
+         // Assert
+
+         invertedLength.Should().Be( maxLength );
       }
 
       [Fact]
       public void Convert_InputIsMaxOf72_ReturnsZero()
       {
-         var converter = new TextLengthInversionConverter();
+         const int maxLength = 72;
 
-         int invertedLength = (int) converter.Convert( 72, null, null, null );
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+         appSettingsMock.SetupGet( @as => @as.MaxCommitLength ).Returns( maxLength );
+
+         // Act
+
+         var converter = new TextLengthInversionConverter( appSettingsMock.Object );
+
+         int invertedLength = (int) converter.Convert( maxLength, null, null, null );
+
+         // Assert
 
          invertedLength.Should().Be( 0 );
       }
@@ -29,9 +53,20 @@ namespace GitWrite.UnitTests.Views.Converters
       [Fact]
       public void Convert_InputIsNegative_ReturnsZero()
       {
-         var converter = new TextLengthInversionConverter();
+         const int maxLength = 72;
+
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+         appSettingsMock.SetupGet( @as => @as.MaxCommitLength ).Returns( maxLength );
+
+         // Act
+
+         var converter = new TextLengthInversionConverter( appSettingsMock.Object );
 
          int invertedLength = (int) converter.Convert( -1, null, null, null );
+
+         // Assert
 
          invertedLength.Should().Be( 0 );
       }
@@ -39,9 +74,20 @@ namespace GitWrite.UnitTests.Views.Converters
       [Fact]
       public void Convert_InputIsGreaterThanMaxOf72_ReturnsZero()
       {
-         var converter = new TextLengthInversionConverter();
+         const int maxLength = 72;
 
-         int invertedLength = (int) converter.Convert( 73, null, null, null );
+         // Arrange
+
+         var appSettingsMock = new Mock<IApplicationSettings>();
+         appSettingsMock.SetupGet( @as => @as.MaxCommitLength ).Returns( maxLength );
+
+         // Act
+
+         var converter = new TextLengthInversionConverter( appSettingsMock.Object );
+
+         int invertedLength = (int) converter.Convert( maxLength + 1, null, null, null );
+
+         // Assert
 
          invertedLength.Should().Be( 0 );
       }

--- a/src/GitWrite/GitWrite/Services/ApplicationSettings.cs
+++ b/src/GitWrite/GitWrite/Services/ApplicationSettings.cs
@@ -55,6 +55,20 @@ namespace GitWrite.Services
          }
       }
 
+      public int MaxCommitLength
+      {
+         get
+         {
+            int storedValue = _registryService.ReadInt( Registry.CurrentUser, _path, nameof( MaxCommitLength ) );
+
+            return storedValue == 0 ? 72 : storedValue;
+         }
+         set
+         {
+            _registryService.WriteInt( Registry.CurrentUser, _path, nameof( MaxCommitLength ), value );
+         }
+      }
+
       public ApplicationSettings( IRegistryService registryService )
       {
          _registryService = registryService;

--- a/src/GitWrite/GitWrite/Services/IApplicationSettings.cs
+++ b/src/GitWrite/GitWrite/Services/IApplicationSettings.cs
@@ -25,5 +25,11 @@
          get;
          set;
       }
+
+      int MaxCommitLength
+      {
+         get;
+         set;
+      }
    }
 }

--- a/src/GitWrite/GitWrite/Services/RegistryService.cs
+++ b/src/GitWrite/GitWrite/Services/RegistryService.cs
@@ -12,7 +12,7 @@ namespace GitWrite.Services
          => OpenKey( registryKey, path, k => k.SetValue( name, value ) );
 
       public int ReadInt( RegistryKey registryKey, string path, string name )
-         => OpenKey( registryKey, path, k => (int) k.GetValue( name ) );
+         => OpenKey( registryKey, path, k => (int) k.GetValue( name, 0 ) );
 
       public void WriteInt( RegistryKey registryKey, string path, string name, int value )
          => OpenKey( registryKey, path, k => k.SetValue( name, value ) );

--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
@@ -25,6 +25,8 @@ namespace GitWrite.Views
       {
          InitializeComponent();
 
+         MainEntryBox.MaxLength = _applicationSettings.MaxCommitLength;
+
          _viewModel = (CommitViewModel) DataContext;
          _viewModel.ExpansionRequested += OnExpansionRequested;
          _viewModel.CollapseRequested += OnCollapseRequested;

--- a/src/GitWrite/GitWrite/Views/Controls/MainEntryBox.xaml
+++ b/src/GitWrite/GitWrite/Views/Controls/MainEntryBox.xaml
@@ -43,7 +43,7 @@
                Foreground="{DynamicResource TextColor}"
                FontFamily="Consolas"
                FontSize="24"
-               MaxLength="72"
+               MaxLength="{Binding MaxLength, Mode=OneWay}"
                HorizontalAlignment="Stretch"
                Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
             </TextBox>

--- a/src/GitWrite/GitWrite/Views/Controls/MainEntryBox.xaml.cs
+++ b/src/GitWrite/GitWrite/Views/Controls/MainEntryBox.xaml.cs
@@ -3,6 +3,8 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Media;
+using GalaSoft.MvvmLight.Ioc;
+using GitWrite.Services;
 
 namespace GitWrite.Views.Controls
 {
@@ -27,6 +29,23 @@ namespace GitWrite.Views.Controls
          set
          {
             SetValue( TextProperty, value );
+         }
+      }
+
+      public static DependencyProperty MaxLengthProperty = DependencyProperty.Register( nameof( MaxLength ),
+         typeof( int ),
+         typeof( MainEntryBox ),
+         new PropertyMetadata( 0 ) );
+
+      public int MaxLength
+      {
+         get
+         {
+            return (int) GetValue( MaxLengthProperty );
+         }
+         set
+         {
+            SetValue( MaxLengthProperty, value );
          }
       }
 

--- a/src/GitWrite/GitWrite/Views/Converters/StringLengthToProgressConverter.cs
+++ b/src/GitWrite/GitWrite/Views/Converters/StringLengthToProgressConverter.cs
@@ -1,11 +1,27 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using GalaSoft.MvvmLight.Ioc;
+using GitWrite.Services;
 
 namespace GitWrite.Views.Converters
 {
    public class StringLengthToProgressConverter : IValueConverter
    {
+      private readonly int _maxLength;
+
+      public StringLengthToProgressConverter()
+      {
+         var appSettings = SimpleIoc.Default.GetInstance<IApplicationSettings>();
+
+         _maxLength = appSettings.MaxCommitLength;
+      }
+
+      public StringLengthToProgressConverter( IApplicationSettings appSettings )
+      {
+         _maxLength = appSettings.MaxCommitLength;
+      }
+
       public object Convert( object value, Type targetType, object parameter, CultureInfo culture )
       {
          if ( value == null )
@@ -20,7 +36,7 @@ namespace GitWrite.Views.Converters
             return 0.0;
          }
 
-         return doubleValue / 72;
+         return doubleValue / _maxLength;
       }
 
       public object ConvertBack( object value, Type targetType, object parameter, CultureInfo culture )

--- a/src/GitWrite/GitWrite/Views/Converters/TextLengthInversionConverter.cs
+++ b/src/GitWrite/GitWrite/Views/Converters/TextLengthInversionConverter.cs
@@ -1,21 +1,36 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using GalaSoft.MvvmLight.Ioc;
+using GitWrite.Services;
 
 namespace GitWrite.Views.Converters
 {
    public class TextLengthInversionConverter : IValueConverter
    {
+      private readonly int _maxLength;
+
+      public TextLengthInversionConverter()
+      {
+         var appSettings = SimpleIoc.Default.GetInstance<IApplicationSettings>();
+         _maxLength = appSettings.MaxCommitLength;
+      }
+
+      public TextLengthInversionConverter( IApplicationSettings appSettings )
+      {
+         _maxLength = appSettings.MaxCommitLength;
+      }
+
       public object Convert( object value, Type targetType, object parameter, CultureInfo culture )
       {
          int textLength = (int) value;
 
-         if ( textLength < 0 || textLength > 72 )
+         if ( textLength < 0 || textLength > _maxLength )
          {
             return 0;
          }
 
-         return 72 - textLength;
+         return _maxLength - textLength;
       }
 
       public object ConvertBack( object value, Type targetType, object parameter, CultureInfo culture )


### PR DESCRIPTION
Now defaults to 72 (in one spot), but can be configured via registry key.