### PR TITLE
Now passes through for "git add -e"

### DIFF
--- a/src/GitWrite/GitWrite.UnitTests/ApplicationModeInterpreterTests.cs
+++ b/src/GitWrite/GitWrite.UnitTests/ApplicationModeInterpreterTests.cs
@@ -52,5 +52,13 @@ namespace GitWrite.UnitTests
 
          applicationMode.Should().Be( ApplicationMode.EditPatch );
       }
+
+      [Fact]
+      public void GetFromFileName_PassingAddEditPatch_ReturnsEditMode()
+      {
+         var applicationMode = ApplicationModeInterpreter.GetFromFileName( GitFileNames.AddEditPatchFileName );
+
+         applicationMode.Should().Be( ApplicationMode.EditPatch );
+      }
    }
 }

--- a/src/GitWrite/GitWrite/ApplicationMode.cs
+++ b/src/GitWrite/GitWrite/ApplicationMode.cs
@@ -11,6 +11,7 @@
       InteractiveRebase,
 
       [GitFile( GitFileNames.EditPatchFileName )]
+      [GitFile( GitFileNames.AddEditPatchFileName )]
       EditPatch
    }
 }

--- a/src/GitWrite/GitWrite/ApplicationModeInterpreter.cs
+++ b/src/GitWrite/GitWrite/ApplicationModeInterpreter.cs
@@ -14,16 +14,13 @@ namespace GitWrite
             var memberType = enumType.GetMember( enumValue.ToString() );
             var gitFileAttributes = memberType[0].GetCustomAttributes( typeof( GitFileAttribute ), false );
 
-            if ( gitFileAttributes.Length == 1 )
+            foreach ( GitFileAttribute attribute in gitFileAttributes )
             {
-               var attribute = (GitFileAttribute) gitFileAttributes[0];
-
                if ( attribute.FileName == fileName )
                {
                   return (ApplicationMode) enumValue;
                }
             }
-
          }
 
          return ApplicationMode.Unknown;

--- a/src/GitWrite/GitWrite/GitFileNames.cs
+++ b/src/GitWrite/GitWrite/GitFileNames.cs
@@ -5,5 +5,6 @@
       public const string CommitFileName = "COMMIT_EDITMSG";
       public const string InteractiveRebaseFileName = "git-rebase-todo";
       public const string EditPatchFileName = "addp-hunk-edit.diff";
+      public const string AddEditPatchFileName = "ADD_EDIT.patch";
    }
 }


### PR DESCRIPTION
This passes in a different file name than "git add -p" followed by "e." We now watch for this other file name.