### PR TITLE
Now restores the counter on window re-activate

### DIFF
--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml
@@ -20,7 +20,8 @@
    DataContext="{Binding CommitViewModel, Source={StaticResource ViewModelLocator}}"
    Loaded="CommitWindow_OnLoaded"
    PreviewKeyDown="CommitWindow_OnPreviewKeyDown"
-   PreviewKeyUp="CommitWindow_OnPreviewKeyUp">
+   PreviewKeyUp="CommitWindow_OnPreviewKeyUp"
+   Activated="CommitWindow_OnActivated">
 
    <Window.Resources>
       <ResourceDictionary>

--- a/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
+++ b/src/GitWrite/GitWrite/Views/CommitWindow.xaml.cs
@@ -347,8 +347,19 @@ namespace GitWrite.Views
 
          if ( wasSystemKey || wasNormalKey )
          {
+            RestoreCounter();
+         }
+      }
+
+      private void CommitWindow_OnActivated( object sender, EventArgs e ) => RestoreCounter();
+
+      private void RestoreCounter()
+      {
+         if ( _isCtrlDown )
+         {
             MainEntryBox.RestoreCounter();
             _isCtrlDown = false;
+
          }
       }
    }


### PR DESCRIPTION
This fixes the bug where you have Ctrl down as the window loses focus (like if you Ctrl+Esc, or something else steals the focus). Going back to GitWrite will play the animation for hiding the arrow, bringing back the counter.