### PR TITLE
More IOC cleanup

### DIFF
--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -104,7 +104,7 @@ namespace GitWrite
          ServiceLocator.SetLocatorProvider( () => SimpleIoc.Default );
 
          SimpleIoc.Default.Register<IApplicationSettings>( () => new ApplicationSettings() );
-         SimpleIoc.Default.Register<ICommitFileReader>( () => new CommitFileReader() );
+         SimpleIoc.Default.Register<ICommitFileReader, CommitFileReader>();
          SimpleIoc.Default.Register<IStoryboardHelper, StoryboardHelper>();
          SimpleIoc.Default.Register<IFileAdapter, FileAdapter>();
          SimpleIoc.Default.Register<IAppService, AppService>();

--- a/src/GitWrite/GitWrite/App.xaml.cs
+++ b/src/GitWrite/GitWrite/App.xaml.cs
@@ -103,7 +103,7 @@ namespace GitWrite
       {
          ServiceLocator.SetLocatorProvider( () => SimpleIoc.Default );
 
-         SimpleIoc.Default.Register<IApplicationSettings>( () => new ApplicationSettings() );
+         SimpleIoc.Default.Register<IApplicationSettings, ApplicationSettings>();
          SimpleIoc.Default.Register<ICommitFileReader, CommitFileReader>();
          SimpleIoc.Default.Register<IStoryboardHelper, StoryboardHelper>();
          SimpleIoc.Default.Register<IFileAdapter, FileAdapter>();

--- a/src/GitWrite/GitWrite/CommitFileReader.cs
+++ b/src/GitWrite/GitWrite/CommitFileReader.cs
@@ -1,16 +1,10 @@
 ﻿using System;
-using GalaSoft.MvvmLight.Ioc;
 
 namespace GitWrite
 {
    public class CommitFileReader : ICommitFileReader
    {
       private readonly IFileAdapter _fileAdapter;
-
-      public CommitFileReader()
-      {
-         _fileAdapter = SimpleIoc.Default.GetInstance<IFileAdapter>();
-      }
 
       public CommitFileReader( IFileAdapter fileAdapter )
       {

--- a/src/GitWrite/GitWrite/Services/ApplicationSettings.cs
+++ b/src/GitWrite/GitWrite/Services/ApplicationSettings.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Win32;
-using GalaSoft.MvvmLight.Ioc;
 
 namespace GitWrite.Services
 {
@@ -69,11 +68,6 @@ namespace GitWrite.Services
          {
             _registryService.WriteInt( Registry.CurrentUser, _path, nameof( MaxCommitLength ), value );
          }
-      }
-
-      public ApplicationSettings()
-      {
-         _registryService = SimpleIoc.Default.GetInstance<IRegistryService>();
       }
 
       public ApplicationSettings( IRegistryService registryService )


### PR DESCRIPTION
Now registering type for CommitFileReader and ApplicationSettings, instead of using the lambda registration. Cured the "multi-constructor" problem by ditching the default constructors. Now these classes don't know what IOC is, but can still be resolved via IOC. :+1: