### PR TITLE
+Margin for the primary text box for commit notes

### DIFF
--- a/src/GitWrite/GitWrite/Views/Controls/MainEntryBox.xaml
+++ b/src/GitWrite/GitWrite/Views/Controls/MainEntryBox.xaml
@@ -45,6 +45,7 @@
                FontSize="24"
                MaxLength="{Binding MaxLength, Mode=OneWay}"
                HorizontalAlignment="Stretch"
+               Margin="0,0,72,0"
                Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
             </TextBox>
          </Border>


### PR DESCRIPTION
As text hangs off the edge this looks much better, since it forces the text to be wholly visible, instead of hidden behind the radial counter.

This happens when editing/amending a commit whose text is above the limit, so you'll get a free pass on the length for that commit.