### PR TITLE
Now generates materials after the UI has loaded

### DIFF
--- a/src/GitWrite/GitWrite/Views/WindowBase.cs
+++ b/src/GitWrite/GitWrite/Views/WindowBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interactivity;
 using System.Windows.Media.Imaging;
@@ -39,16 +38,9 @@ namespace GitWrite.Views
          Icon = BitmapFrame.Create( iconUri );
       }
 
-      private async void OnLoaded( object sender, EventArgs e )
+      private void OnLoaded( object sender, EventArgs e )
       {
          _viewModel = (GitWriteViewModelBase) DataContext;
-          
-         await Task.Delay( 200 );
-
-         string saveText = GetSaveText();
-
-         var materialGenerator = new MaterialGenerator( this );
-         await materialGenerator.GenerateAsync( saveText );
       }
 
       private void OnClosing( object sender, CancelEventArgs e )
@@ -74,18 +66,6 @@ namespace GitWrite.Views
             default:
                return ExitReason.Cancel;
          }
-      }
-
-      private string GetSaveText()
-      {
-         var commitViewModel = _viewModel as CommitViewModel;
-
-         if ( commitViewModel != null )
-         {
-            return commitViewModel.IsAmending ? Resx.AmendingText : Resx.CommittingText;
-         }
-
-         return null;
       }
    }
 }


### PR DESCRIPTION
This ensures the startup animation is nice and smooth, so startup time isn't affected by this process. When done concurrently, it did make the animation choppy, since it was doing so much.

Now, we wait til the window has fully loaded to create the materials. This meant that you could also exit the app before the materials had finished generating. Now the exit process awaits the material generation task, so if you exit quickly, you may have to wait a tiny amount for the materials to finish. This is pretty unnoticeable, and you'd have to exit basically immediately after the app started; this case isn't practical, but DOES prevent a crash, which is why it's in there.